### PR TITLE
add multithreading to speed up

### DIFF
--- a/src/pattern_detection.jl
+++ b/src/pattern_detection.jl
@@ -4,10 +4,10 @@ function slow_filter(img)
 end
 
 
-function fast_filter!(dat_filtered, kernel, dat) #
+function fast_filter(kernel, dat) #
     #r = Images.ImageFiltering.ComputationalResources.CPU1(Images.ImageFiltering.FIR())
-    DSP.filt!(dat_filtered, kernel[1].data.parent, dat)
-    return dat_filtered
+    filter_result = DSP.filt(kernel[1].data.parent, dat)
+    return filter_result
 end
 
 function single_chan_pattern_detector(dat, func, evts)
@@ -48,7 +48,7 @@ function mult_chan_pattern_detector_probability(dat, stat_function, evts; n_perm
         for ch = 1:size(dat, 1)
             sortix = shuffle(1:size(dat_filtered, 1))
             d_perm[ch, perm] = stat_function(
-                fast_filter!(dat_filtered, kernel, @view(dat_padded[ch, sortix, :])),
+                fast_filter(kernel, @view(dat_padded[ch, sortix, :])),
             )
             @show ch, perm
         end
@@ -59,7 +59,7 @@ function mult_chan_pattern_detector_probability(dat, stat_function, evts; n_perm
         sortix = sortperm(evts[!, n])
         col = fill(NaN, size(dat, 1))
         for ch = 1:size(dat, 1)
-            fast_filter!(dat_filtered, kernel, @view(dat_padded[ch, sortix, :]))
+            fast_filter(kernel, @view(dat_padded[ch, sortix, :]))
             d_emp = stat_function(dat_filtered)
 
             col[ch] = abs(d_emp - mean_d_perm[ch])

--- a/src/pattern_detection.jl
+++ b/src/pattern_detection.jl
@@ -59,8 +59,9 @@ function mult_chan_pattern_detector_probability(dat, stat_function, evts; n_perm
         sortix = sortperm(evts[!, n])
         col = fill(NaN, size(dat, 1))
         for ch = 1:size(dat, 1)
-            fast_filter(kernel, @view(dat_padded[ch, sortix, :]))
-            d_emp = stat_function(dat_filtered)
+            d_emp = stat_function(
+                fast_filter(kernel, @view(dat_padded[ch, sortix, :]))
+            )
 
             col[ch] = abs(d_emp - mean_d_perm[ch])
             print(ch, " ")

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -1,3 +1,7 @@
+# FOR MULTITHREADING: 
+# run: >julia -t [n_threads]
+# instead of [n_threads] write a desired number of threads (<= amount of CPU cores)
+
 include("setup.jl")
 include("pattern_detection.jl")
 
@@ -27,6 +31,13 @@ end
 
 fid = h5open("data/mult.hdf5", "r")
 dat2 = read(fid["data"]["mult.hdf5"])
+close(fid)
+
+# Data for multiple channels (only fixations)
+# 128 channels x 769 time x 2508 events 
+
+fid = h5open("data_fixations/data_fixations.hdf5", "r")
+dat_fix = read(fid["data"]["data_fixations.hdf5"])
 close(fid)
 
 
@@ -63,6 +74,11 @@ evts_init = CSV.read("data/events_init.csv", DataFrame)
 @time begin
     ix = evts_init.type .== "fixation"
     evts_d = mult_chan_pattern_detector_probability(dat2[:, :, ix], Images.entropy, evts) 
+end
+
+# PATTERN DETECTION 4 (FOR FIXATIONS ONLY)
+@time begin
+    evts_d = mult_chan_pattern_detector_probability(dat_fix, Images.entropy, evts) 
 end
 
 begin

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -36,7 +36,7 @@ close(fid)
 # Data for multiple channels (only fixations)
 # 128 channels x 769 time x 2508 events 
 
-fid = h5open("data_fixations/data_fixations.hdf5", "r")
+fid = h5open("data/data_fixations.hdf5", "r")
 dat_fix = read(fid["data"]["data_fixations.hdf5"])
 close(fid)
 
@@ -77,6 +77,7 @@ evts_init = CSV.read("data/events_init.csv", DataFrame)
 end
 
 # PATTERN DETECTION 4 (FOR FIXATIONS ONLY)
+# 10 cores: 50 s
 @time begin
     evts_d = mult_chan_pattern_detector_probability(dat_fix, Images.entropy, evts) 
 end


### PR DESCRIPTION
Use **Threads** to run fast_filter across permutations and channels in parallel: Issue #7 